### PR TITLE
Revert "chore(deps): update ghcr.io/siderolabs/kubelet docker tag to v1.32.0"

### DIFF
--- a/clusters/main/kubernetes/flux-system/flux/upgradesettings.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/upgradesettings.yaml
@@ -7,4 +7,4 @@ data:
   # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
   TALOS_VERSION: v1.8.4
   # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-  KUBERNETES_VERSION: v1.32.0
+  KUBERNETES_VERSION: v1.31.4

--- a/clusters/main/talos/talconfig.yaml
+++ b/clusters/main/talos/talconfig.yaml
@@ -2,7 +2,7 @@ clusterName: ${CLUSTERNAME}
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.8.4
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.32.0
+kubernetesVersion: v1.31.4
 endpoint: https://${VIP}:6443
 allowSchedulingOnControlPlanes: true
 additionalMachineCertSans:


### PR DESCRIPTION
Reverts UberElectron/UberCluster#18

Kubernetes 1.32.0 it's not yet supported on Talos 1.8.4:
- See: https://www.talos.dev/v1.8/introduction/support-matrix/